### PR TITLE
Fix compiler errors and warnings

### DIFF
--- a/test_mvgaussian_redsea_mpi.cpp
+++ b/test_mvgaussian_redsea_mpi.cpp
@@ -243,7 +243,7 @@ int main(int argc, char *argv[])
   // time it
   timer.Start();
 
-  for (int i = 0; i < dsList.size(); i++)
+  for (std::size_t i = 0; i < dsList.size(); i++)
   {
     callWorklet(dsList[i], isovalue, num_samples, "stru");
   }

--- a/ucv_umc.cpp
+++ b/ucv_umc.cpp
@@ -123,7 +123,7 @@ public:
         negativeProbList.resize(numPoints);
 
         // there are 2^n total cases
-        int totalNumCases = static_cast<int>(vtkm::Pow(2.0, static_cast<vtkm::FloatDefault>(numPoints)));
+        int totalNumCases = static_cast<int>(vtkm::Pow(2.0f, static_cast<float>(numPoints)));
         std::vector<vtkm::FloatDefault> probHistogram;
 
         probHistogram.resize(totalNumCases);

--- a/ucvworklet/MVGaussianWithEnsemble2DPolyTryLialgEntropy.hpp
+++ b/ucvworklet/MVGaussianWithEnsemble2DPolyTryLialgEntropy.hpp
@@ -50,7 +50,7 @@ public:
         // TODO, using numVertexies to decide the length of mean and cov
         // and decide them at the runtime
 
-        vtkm::Vec<vtkm::FloatDefault, 3> meanArray;
+        vtkm::Vec3f_64 meanArray;
 
         // get the type in the fieldVec
         // the VecType specifies the number of ensembles

--- a/ucvworklet/MVGaussianWithEnsemble2DTryLialg.hpp
+++ b/ucvworklet/MVGaussianWithEnsemble2DTryLialg.hpp
@@ -45,7 +45,7 @@ public:
             return;
         }
 
-        vtkm::Vec<vtkm::FloatDefault, 4> meanArray;
+        vtkm::Vec4f_64 meanArray;
 
         // get the type in the fieldVec
         // the VecType specifies the number of ensembles

--- a/ucvworklet/MVGaussianWithEnsemble2DTryLialgEntropy.hpp
+++ b/ucvworklet/MVGaussianWithEnsemble2DTryLialgEntropy.hpp
@@ -46,7 +46,7 @@ public:
             return;
         }
 
-        vtkm::Vec<vtkm::FloatDefault, 4> meanArray;
+        vtkm::Vec4f_64 meanArray;
 
         // get the type in the fieldVec
         // the VecType specifies the number of ensembles

--- a/ucvworklet/MVGaussianWithEnsemble3D.hpp
+++ b/ucvworklet/MVGaussianWithEnsemble3D.hpp
@@ -101,7 +101,7 @@ public:
         
         // TODO There are still some issues to make it work properly on for cuda version
         // Maybe look at the possible alternative functions in future
-        Eigen::EigenMultivariateNormal<vtkm::FloatDefault> normX_solver(meanVector, covMatrix);
+        Eigen::EigenMultivariateNormal<double> normX_solver(meanVector, covMatrix);
         
         auto R = normX_solver.samples(numSamples).transpose();
 

--- a/ucvworklet/linalg/test_ucv_matrix_static_8by8.cpp
+++ b/ucvworklet/linalg/test_ucv_matrix_static_8by8.cpp
@@ -171,7 +171,7 @@ void test_eigen_vectors_8by8()
 {
 
     printf("---test test_eigen_vectors_8by8\n");
-    int dim = 8;
+    constexpr int dim = 8;
     mat_t x;
     for (int i = 0; i < dim; i++)
     {

--- a/ucvworklet/linalg/ucv_matrix_static_3by3.h
+++ b/ucvworklet/linalg/ucv_matrix_static_3by3.h
@@ -30,17 +30,19 @@ namespace UCVMATH_THREE
      
     #define MSIZE 3
 
-    typedef struct
+    struct mat_t
     {
         int m = MSIZE, n = MSIZE; // m is row, n is column
-        double v[MSIZE][MSIZE] = {0};
-    } mat_t, *mat;
+        double v[MSIZE][MSIZE] = {{0}};
+    };
+    using mat = mat_t*;
 
-    typedef struct
+    struct vec_t
     {
         int len = MSIZE;
         double v[MSIZE] = {0};
-    } vec_t, *vec;
+    };
+    using vec = vec_t*;
 
     VTKM_EXEC inline vec_t vec_new(int len)
     {
@@ -412,8 +414,7 @@ namespace UCVMATH_THREE
 
         mat_t qq = matrix_new_eye(x->m, x->m);
 
-        int i = 0;
-        while (true)
+        for (int i = 0; i < max_iter; ++i)
         {
 
             // it is not ok to init the empty pointer on cuda device by this way
@@ -441,8 +442,7 @@ namespace UCVMATH_THREE
             // update the qq to newq
             qq = newq;
 
-            i++;
-            if (matrix_is_upper_triangular(&ak, tol) || i > max_iter)
+            if (matrix_is_upper_triangular(&ak, tol))
             {
                 // matrix_show(m);
                 // printf("iter %d\n", i);

--- a/ucvworklet/linalg/ucv_matrix_static_4by4.h
+++ b/ucvworklet/linalg/ucv_matrix_static_4by4.h
@@ -26,17 +26,19 @@ namespace UCVMATH
     // https://stackoverflow.com/questions/34820324/macro-for-dynamic-types-in-c
     // or maybe use the code generation tool in future
 
-    typedef struct
+    struct mat_t
     {
         int m = 4, n = 4; // m is row, n is column
-        double v[4][4] = {0};
-    } mat_t, *mat;
+        double v[4][4] = {{0}};
+    };
+    using mat = mat_t*;
 
-    typedef struct
+    struct vec_t
     {
         int len = 4;
         double v[4] = {0};
-    } vec_t, *vec;
+    };
+    using vec = vec_t*;
 
     VTKM_EXEC inline vec_t vec_new(int len)
     {
@@ -408,8 +410,7 @@ namespace UCVMATH
 
         mat_t qq = matrix_new_eye(x->m, x->m);
 
-        int i = 0;
-        while (true)
+        for (int i = 0; i < max_iter; ++i)
         {
 
             // it is not ok to init the empty pointer on cuda device by this way
@@ -437,8 +438,7 @@ namespace UCVMATH
             // update the qq to newq
             qq = newq;
 
-            i++;
-            if (matrix_is_upper_triangular(&ak, tol) || i > max_iter)
+            if (matrix_is_upper_triangular(&ak, tol))
             {
                 // matrix_show(m);
                 // printf("iter %d\n", i);

--- a/ucvworklet/linalg/ucv_matrix_static_8by8.h
+++ b/ucvworklet/linalg/ucv_matrix_static_8by8.h
@@ -27,17 +27,19 @@ namespace UCVMATH
     // https://stackoverflow.com/questions/34820324/macro-for-dynamic-types-in-c
     // or maybe use the code generation tool in future
 
-    typedef struct
+    struct mat_t
     {
         int m = DIM, n = DIM; // m is row, n is column
-        double v[DIM][DIM] = {0};
-    } mat_t, *mat;
+        double v[DIM][DIM] = {{0}};
+    };
+    using mat = mat_t*;
 
-    typedef struct
+    struct vec_t
     {
         int len = DIM;
         double v[DIM] = {0};
-    } vec_t, *vec;
+    };
+    using vec = vec_t*;
 
     VTKM_EXEC inline vec_t vec_new(int len)
     {
@@ -409,8 +411,7 @@ namespace UCVMATH
 
         mat_t qq = matrix_new_eye(x->m, x->m);
 
-        int i = 0;
-        while (true)
+        for (int i = 0; i < max_iter; ++i)
         {
 
             // it is not ok to init the empty pointer on cuda device by this way
@@ -438,8 +439,7 @@ namespace UCVMATH
             // update the qq to newq
             qq = newq;
 
-            i++;
-            if (matrix_is_upper_triangular(&ak, tol) || i > max_iter)
+            if (matrix_is_upper_triangular(&ak, tol))
             {
                 // matrix_show(m);
                 // printf("iter %d\n", i);


### PR DESCRIPTION
This fixes several compiler errors and warnings when using a different configuration than Jay. Many of the errors were caused by me compiling VTK-m with default float of 32 bits instead of 64 bits, which caused some incompatible types. Many of the warnings were probably caused because I am using the clang compiler on Mac.